### PR TITLE
Made MessageDialogs optional

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.crownpartners.intellivault</id>
     <name>IntelliVault</name>
-    <version>0.9.3</version>
+    <version>0.9.4-Delaware</version>
     <vendor email="ssteimer@crownpartners.com" url="http://www.crownpartners.com">Crown Partners</vendor>
 
     <description><![CDATA[
@@ -18,6 +18,7 @@
       <li>v0.9.1: Added logging of output to the console, removed extraneous dialog options.</li>
       <li>v0.9.2: Fixing an issue where the temp directory isn't always deleted.</li>
       <li>v0.9.3: Updates to plugin metadata.</li>
+      <li>v0.9.4-Delaware: Added option to bypass message dialogs.</li>
       </ul>
       ]]>
     </change-notes>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.crownpartners.intellivault</id>
     <name>IntelliVault</name>
-    <version>0.9.4-Delaware</version>
+    <version>0.9.3-sdehandt</version>
     <vendor email="ssteimer@crownpartners.com" url="http://www.crownpartners.com">Crown Partners</vendor>
 
     <description><![CDATA[
@@ -18,7 +18,7 @@
       <li>v0.9.1: Added logging of output to the console, removed extraneous dialog options.</li>
       <li>v0.9.2: Fixing an issue where the temp directory isn't always deleted.</li>
       <li>v0.9.3: Updates to plugin metadata.</li>
-      <li>v0.9.4-Delaware: Added option to bypass message dialogs.</li>
+      <li>v0.9.3-sdehandt: Added option to bypass message dialogs.</li>
       </ul>
       ]]>
     </change-notes>

--- a/src/com/crownpartners/intellivault/actions/IntelliVaultAbstractAction.java
+++ b/src/com/crownpartners/intellivault/actions/IntelliVaultAbstractAction.java
@@ -46,12 +46,13 @@ public abstract class IntelliVaultAbstractAction extends AnAction {
         final PsiDirectory psiDir = getCRXDirectory(evt);
         final VaultOperationDirectory vaultOpDir = new VaultOperationDirectory(psiDir,conf.getRootFolderName());
 
-        int result =
+        boolean proceed = !conf.showMessageDialogs() ||
+                (
                 Messages.showYesNoDialog(String.format(getDialogMessage(),new Object[]{
                         repository.getRepoUrl() + vaultOpDir.getJcrPath(),
                         vaultOpDir.getPsiDir().getVirtualFile().getCanonicalPath()}), "Run IntelliVault?",
-                        Messages.getQuestionIcon());
-        if (result == Messages.YES) {
+                        Messages.getQuestionIcon()) == Messages.YES);
+        if (proceed) {
             Project project = evt.getData(PlatformDataKeys.PROJECT);
             ProgressManager.getInstance().run(getTask(vaultOpDir, conf, repository, project));
         }

--- a/src/com/crownpartners/intellivault/actions/IntelliVaultExportAction.java
+++ b/src/com/crownpartners/intellivault/actions/IntelliVaultExportAction.java
@@ -80,14 +80,17 @@ public class IntelliVaultExportAction extends IntelliVaultAbstractAction {
             final IntelliVaultService vaultService = getVaultService();
             try {
                 vaultService.vaultExport(repository, conf, vaultOpDir, progressIndicator, console);
-                ApplicationManager.getApplication().invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        Messages.showInfoMessage(String.format("Successfully Exported from %s.",
-                                new Object[]{repository.getRepoUrl() + vaultOpDir.getJcrPath()}),
-                                "IntelliVault Export Completed Successfully!");
-                    }
-                });
+
+                if (conf.showMessageDialogs()) {
+                    ApplicationManager.getApplication().invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            Messages.showInfoMessage(String.format("Successfully Exported from %s.",
+                                    new Object[]{repository.getRepoUrl() + vaultOpDir.getJcrPath()}),
+                                    "IntelliVault Export Completed Successfully!");
+                        }
+                    });
+                }
             } catch (final IntelliVaultException e) {
                 ApplicationManager.getApplication().invokeLater(new Runnable() {
                     @Override

--- a/src/com/crownpartners/intellivault/actions/IntelliVaultImportAction.java
+++ b/src/com/crownpartners/intellivault/actions/IntelliVaultImportAction.java
@@ -30,7 +30,7 @@ public class IntelliVaultImportAction extends IntelliVaultAbstractAction {
     @Override
     protected Task getTask(VaultOperationDirectory vaultOpDir, IntelliVaultOperationConfig conf,
                            IntelliVaultCRXRepository repository, Project project) {
-        return new IntelliVaultImportTask(vaultOpDir,conf,repository,project);
+        return new IntelliVaultImportTask(vaultOpDir, conf, repository, project);
     }
 
     protected String getDialogMessage() {
@@ -51,16 +51,16 @@ public class IntelliVaultImportAction extends IntelliVaultAbstractAction {
          * Construct the Instance to be executed.
          *
          * @param vaultOpDir the Vault Operation Directory
-         * @param conf the Vault Configuration Options
+         * @param conf       the Vault Configuration Options
          * @param repository the CRX Repository to import into
-         * @param project the IntelliJ Project
+         * @param project    the IntelliJ Project
          */
         public IntelliVaultImportTask(VaultOperationDirectory vaultOpDir, IntelliVaultOperationConfig conf,
                                       IntelliVaultCRXRepository repository, Project project) {
-            super(project,"Running IntelliVault Import Action");
-            this.conf=conf;
-            this.repository=repository;
-            this.vaultOpDir=vaultOpDir;
+            super(project, "Running IntelliVault Import Action");
+            this.conf = conf;
+            this.repository = repository;
+            this.vaultOpDir = vaultOpDir;
 
             TextConsoleBuilderFactory factory = TextConsoleBuilderFactory.getInstance();
             this.console = factory.createBuilder(project).getConsole();
@@ -68,7 +68,7 @@ public class IntelliVaultImportAction extends IntelliVaultAbstractAction {
             ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
             String twId = "IntelliVault";
             ToolWindow toolWindow = toolWindowManager.getToolWindow(twId);
-            if(toolWindow==null) {
+            if (toolWindow == null) {
                 toolWindow = toolWindowManager.registerToolWindow(twId, true, ToolWindowAnchor.BOTTOM);
             }
 
@@ -92,16 +92,20 @@ public class IntelliVaultImportAction extends IntelliVaultAbstractAction {
         public void run(@NotNull ProgressIndicator progressIndicator) {
             IntelliVaultService vaultService = getVaultService();
             try {
-                vaultService.vaultImport(repository, conf, vaultOpDir,progressIndicator, console);
-                ApplicationManager.getApplication().invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        Messages.showInfoMessage(String.format("Successfully Imported to %s.",
-                                new Object[]{repository.getRepoUrl() + vaultOpDir.getJcrPath()}),
-                                "IntelliVault Import Completed Successfully!");
-                    }
-                });
-            } catch (final IntelliVaultException e) {
+                vaultService.vaultImport(repository, conf, vaultOpDir, progressIndicator, console);
+                if (conf.showMessageDialogs()) {
+                    ApplicationManager.getApplication().invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            Messages.showInfoMessage(String.format("Successfully Imported to %s.",
+                                            new Object[]{repository.getRepoUrl() + vaultOpDir.getJcrPath()}),
+                                    "IntelliVault Import Completed Successfully!"
+                            );
+                        }
+                    });
+                }
+            }
+            catch (final IntelliVaultException e) {
                 ApplicationManager.getApplication().invokeLater(new Runnable() {
                     @Override
                     public void run() {

--- a/src/com/crownpartners/intellivault/config/IntelliVaultConfigDefaults.java
+++ b/src/com/crownpartners/intellivault/config/IntelliVaultConfigDefaults.java
@@ -9,6 +9,7 @@ package com.crownpartners.intellivault.config;
  */
 public class IntelliVaultConfigDefaults {
 
+
     /**
      * Private default constructor to prevent creation of isntances of this class.
      */
@@ -21,12 +22,13 @@ public class IntelliVaultConfigDefaults {
     public static final String REPO_PASSWORD="admin";
 
     public static final String ROOT_FOLDER="jcr_root";
-    public static final String IGNORE_PATTERNS=".svn,.vlt,CVS";
+    public static final String IGNORE_PATTERNS=".svn,.vlt,CVS,.DS_Store";
 
     public static final boolean VERBOSE=true;
     public static final boolean CONSOLE_LOG=false;
     public static final boolean DEBUG=false;
 
+    public static final boolean SHOW_MESSAGE_DIALOG = true;
 
     public static final String VAULT_PATH = "";
 }

--- a/src/com/crownpartners/intellivault/config/IntelliVaultOperationConfig.java
+++ b/src/com/crownpartners/intellivault/config/IntelliVaultOperationConfig.java
@@ -20,6 +20,7 @@ public class IntelliVaultOperationConfig {
     private boolean debug;
     private boolean logToConsole;
     private List<String> fileIgnorePatterns;
+    private boolean showMessageDialogs;
 
     /**
      * Create a new instance using the default value for all fields of the operation config
@@ -32,6 +33,7 @@ public class IntelliVaultOperationConfig {
         this.debug=IntelliVaultConfigDefaults.DEBUG;
         this.logToConsole=IntelliVaultConfigDefaults.CONSOLE_LOG;
         this.fileIgnorePatterns = Arrays.asList(IntelliVaultConfigDefaults.IGNORE_PATTERNS.split(","));
+        this.showMessageDialogs = IntelliVaultConfigDefaults.SHOW_MESSAGE_DIALOG;
     }
 
     public String getVaultPath() {
@@ -88,5 +90,13 @@ public class IntelliVaultOperationConfig {
 
     public void setFileIgnorePatterns(List<String> fileIgnorePatterns) {
         this.fileIgnorePatterns = fileIgnorePatterns;
+    }
+
+    public boolean showMessageDialogs() {
+        return showMessageDialogs;
+    }
+
+    public void setShowMessageDialogs(boolean showMessageDialogs) {
+        this.showMessageDialogs = showMessageDialogs;
     }
 }

--- a/src/com/crownpartners/intellivault/config/IntelliVaultPreferences.java
+++ b/src/com/crownpartners/intellivault/config/IntelliVaultPreferences.java
@@ -24,6 +24,7 @@ public class IntelliVaultPreferences implements Serializable {
     public String tempDirectory;
     public String rootFolderName;
     public boolean verbose;
+    public boolean showDialogs;
     public boolean debug;
     public boolean logToConsole;
     public List<String> fileIgnorePatterns;
@@ -42,6 +43,7 @@ public class IntelliVaultPreferences implements Serializable {
 
         this.verbose = operationConfig.isVerbose();
         this.debug = operationConfig.isDebug();
+        this.showDialogs = operationConfig.showMessageDialogs();
         this.logToConsole = operationConfig.isLogToConsole();
 
         this.fileIgnorePatterns = operationConfig.getFileIgnorePatterns();
@@ -64,6 +66,7 @@ public class IntelliVaultPreferences implements Serializable {
         operationConfig.setVerbose(this.verbose);
         operationConfig.setLogToConsole(this.logToConsole);
         operationConfig.setDebug(this.debug);
+        operationConfig.setShowMessageDialogs(this.showDialogs);
 
         operationConfig.setFileIgnorePatterns(this.fileIgnorePatterns);
 

--- a/src/com/crownpartners/intellivault/ui/IntelliVaultSettingsForm.form
+++ b/src/com/crownpartners/intellivault/ui/IntelliVaultSettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.crownpartners.intellivault.ui.IntelliiVaultSettings">
-  <grid id="27dc6" binding="jPanel" layout-manager="GridLayoutManager" row-count="11" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="jPanel" layout-manager="GridLayoutManager" row-count="12" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -157,12 +157,20 @@
       </component>
       <vspacer id="72d02">
         <constraints>
-          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="3b38a" class="javax.swing.JCheckBox" binding="showDialogsCheckBox">
+        <constraints>
+          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Show Dialogs"/>
+        </properties>
+      </component>
       <component id="e8082" class="javax.swing.JButton" binding="btnRestoreDefaults">
         <constraints>
-          <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Restore Defaults"/>

--- a/src/com/crownpartners/intellivault/ui/IntelliiVaultSettings.java
+++ b/src/com/crownpartners/intellivault/ui/IntelliiVaultSettings.java
@@ -44,6 +44,7 @@ public class IntelliiVaultSettings implements Configurable {
     private JTextField txtIgnorePatterns;
     private JTextField txtJCRRootDirName;
     private JButton btnRestoreDefaults;
+    private JCheckBox showDialogsCheckBox;
 
     @Nls
     @Override
@@ -146,6 +147,7 @@ public class IntelliiVaultSettings implements Configurable {
         preferencesBean.rootFolderName = txtJCRRootDirName.getText();
 
         preferencesBean.verbose = verboseOutputCheckBox.isSelected();
+        preferencesBean.showDialogs = showDialogsCheckBox.isSelected();
 
         String ignorePatterns = txtIgnorePatterns.getText();
         if (ignorePatterns != null) {
@@ -170,6 +172,7 @@ public class IntelliiVaultSettings implements Configurable {
         txtJCRRootDirName.setText(preferences.rootFolderName);
 
         verboseOutputCheckBox.setSelected(preferences.verbose);
+        showDialogsCheckBox.setSelected(preferences.showDialogs);
 
         StringBuffer buf = new StringBuffer();
         for (String s : preferences.fileIgnorePatterns) {


### PR DESCRIPTION
The user can now choose to not show the message dialogs before and after each IntelliVault action. While these might be helpful for occasional use, they can become rather irritating after a while.
